### PR TITLE
Updates druid dependencies version to 0.23.0 and AggregatorFactory Implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>io.imply</groupId>
   <artifactId>druid-example-extension</artifactId>
-  <version>0.13.0_1-SNAPSHOT</version>
+  <version>0.24.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:https://github.com/implydata/druid-example-extension.git</connection>
@@ -32,7 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <druid.version>0.13.0-incubating</druid.version>
+    <druid.version>0.23.0</druid.version>
     <jmh.version>1.9.2</jmh.version>
   </properties>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-api</artifactId>
-      <version>${druid.version}</version>
+      <version>0.13.0-incubating</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/imply/druid/example/aggregator/ExampleSumAggregatorFactory.java
+++ b/src/main/java/io/imply/druid/example/aggregator/ExampleSumAggregatorFactory.java
@@ -28,6 +28,7 @@ import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorFactoryNotMergeableException;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.column.ColumnType;
 
 import java.nio.ByteBuffer;
 import java.util.Comparator;
@@ -162,9 +163,14 @@ public class ExampleSumAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public String getTypeName()
+  public ColumnType getIntermediateType()
   {
-    return "float";
+    return ColumnType.FLOAT;
+  }
+
+  @Override
+  public ColumnType getResultType() {
+    return this.getIntermediateType();
   }
 
   @Override

--- a/src/test/java/io/imply/druid/example/aggregator/ExampleSumAggregatorFactoryTest.java
+++ b/src/test/java/io/imply/druid/example/aggregator/ExampleSumAggregatorFactoryTest.java
@@ -1,0 +1,48 @@
+package io.imply.druid.example.aggregator;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.imply.druid.example.ExampleExtensionModule;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.segment.column.ColumnType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExampleSumAggregatorFactoryTest
+{
+  private static final ObjectMapper MAPPER = new DefaultObjectMapper();
+
+  static {
+    for (Module module : new ExampleExtensionModule().getJacksonModules()) {
+      MAPPER.registerModule(module);
+    }
+  }
+
+  @Test
+  public void testSimple()
+  {
+    final ExampleSumAggregatorFactory agg = new ExampleSumAggregatorFactory("billy", "nilly");
+    Assert.assertEquals("billy", agg.getName());
+    Assert.assertEquals("nilly", agg.getFieldName());
+    Assert.assertEquals(ColumnType.FLOAT, agg.getIntermediateType());
+    Assert.assertEquals(ColumnType.FLOAT, agg.getResultType());
+    Assert.assertEquals(357.2, agg.combine(123.2, 234));
+  }
+
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ExampleSumAggregatorFactory agg = new ExampleSumAggregatorFactory("billy", "nilly");
+
+    Assert.assertEquals(
+        new ExampleSumAggregatorFactory("billy", "nilly"),
+        MAPPER.readValue("{ \"type\" : \"exampleSum\", \"name\" : \"billy\",  \"fieldName\": \"nilly\"}", ExampleSumAggregatorFactory.class)
+    );
+
+    Assert.assertEquals(
+        new ExampleSumAggregatorFactory("billy", "nilly"),
+        MAPPER.readValue(MAPPER.writeValueAsBytes(agg), ExampleSumAggregatorFactory.class)
+    );
+  }
+
+}

--- a/src/test/java/io/imply/druid/example/aggregator/ExampleSumAggregatorTest.java
+++ b/src/test/java/io/imply/druid/example/aggregator/ExampleSumAggregatorTest.java
@@ -1,0 +1,138 @@
+package io.imply.druid.example.aggregator;
+
+import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.TestFloatColumnSelector;
+import org.apache.druid.query.aggregation.TestObjectColumnSelector;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+
+public class ExampleSumAggregatorTest
+{
+  private ExampleSumAggregatorFactory exampleSumAggFactory;
+  private ExampleSumAggregatorFactory combiningAggFactory;
+  private ColumnSelectorFactory colSelectorFactory;
+  private TestFloatColumnSelector valueSelector;
+  private TestObjectColumnSelector objectSelector;
+
+  private float[] floats = {1.1897f, 0.001f, 86.23f, 166.228f};
+  private Float[] objects = {2.1897f, 1.001f, 87.23f, 167.228f};
+
+  @Before
+  public void setup()
+  {
+    exampleSumAggFactory = new ExampleSumAggregatorFactory("billy", "nilly");
+    combiningAggFactory = (ExampleSumAggregatorFactory) exampleSumAggFactory.getCombiningFactory();
+    valueSelector = new TestFloatColumnSelector(floats);
+    objectSelector = new TestObjectColumnSelector<>(objects);
+    colSelectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
+    EasyMock.expect(colSelectorFactory.makeColumnValueSelector("nilly")).andReturn(valueSelector);
+    EasyMock.expect(colSelectorFactory.makeColumnValueSelector("billy")).andReturn(objectSelector);
+    EasyMock.replay(colSelectorFactory);
+  }
+
+  @Test
+  public void testExampleSumAggregator()
+  {
+    Aggregator agg = exampleSumAggFactory.factorize(colSelectorFactory);
+
+    aggregate(agg);
+    aggregate(agg);
+    aggregate(agg);
+    aggregate(agg);
+
+    Double result = (Double) agg.get();
+
+    Assert.assertEquals(253.6487, result, 0.0001);
+    Assert.assertEquals(253L, agg.getLong());
+    Assert.assertEquals(253.6487, agg.getFloat(), 0.0001);
+  }
+
+  @Test
+  public void testExampleSumBufferAggregator()
+  {
+    BufferAggregator agg = exampleSumAggFactory.factorizeBuffered(
+        colSelectorFactory);
+
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[exampleSumAggFactory.getMaxIntermediateSizeWithNulls()]);
+    agg.init(buffer, 0);
+
+    aggregate(agg, buffer, 0);
+    aggregate(agg, buffer, 0);
+    aggregate(agg, buffer, 0);
+    aggregate(agg, buffer, 0);
+
+    Double result = (Double) agg.get(buffer, 0);
+
+    Assert.assertEquals(253.6487, result, 0.0001);
+    Assert.assertEquals( 253L, agg.getLong(buffer, 0));
+    Assert.assertEquals(253.6487, agg.getFloat(buffer, 0), 0.0001);
+  }
+
+  @Test
+  public void testCombine()
+  {
+    Float f1 = 3.0f;
+    Float f2 = 4.0f;
+    Assert.assertEquals((double) (f1+f2), exampleSumAggFactory.combine(f1, f2));
+  }
+
+  @Test
+  public void testComparatorWithNulls()
+  {
+    Float f1 = 3.0f;
+    Float f2 = null;
+    Comparator comparator = exampleSumAggFactory.getComparator();
+    Assert.assertEquals(1, comparator.compare(f1, f2));
+    Assert.assertEquals(0, comparator.compare(f1, f1));
+    Assert.assertEquals(0, comparator.compare(f2, f2));
+    Assert.assertEquals(-1, comparator.compare(f2, f1));
+  }
+
+  @Test
+  public void testFloatAnyCombiningBufferAggregator()
+  {
+    BufferAggregator agg = combiningAggFactory.factorizeBuffered(
+        colSelectorFactory);
+
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[exampleSumAggFactory.getMaxIntermediateSizeWithNulls()]);
+    agg.init(buffer, 0);
+
+    aggregate(agg, buffer, 0);
+    aggregate(agg, buffer, 0);
+    aggregate(agg, buffer, 0);
+    aggregate(agg, buffer, 0);
+
+    Double result = (Double) agg.get(buffer, 0);
+
+    Assert.assertEquals(257.6487, result, 0.0001);
+    Assert.assertEquals(257, agg.getLong(buffer, 0));
+    Assert.assertEquals(257.6487, agg.getFloat(buffer, 0), 0.0001);
+  }
+
+  private void aggregate(
+      Aggregator agg
+  )
+  {
+    agg.aggregate();
+    valueSelector.increment();
+    objectSelector.increment();
+  }
+
+  private void aggregate(
+      BufferAggregator agg,
+      ByteBuffer buff,
+      int position
+  )
+  {
+    agg.aggregate(buff, position);
+    valueSelector.increment();
+    objectSelector.increment();
+  }
+}


### PR DESCRIPTION
#### Description:
The current version of `ExampleSumAggregatorFactory` isn't compatible with the latest version of `AggregatorFactory` any longer. Hence modified it to implement the methods of the latest version of `AggregatorFactory`.  